### PR TITLE
add removal and unique build name to docker compose

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,10 @@ RELEASE=${RELEASE:-false}
 REPOSITORY=${ECR_REGISTRY}/lighthouse-platform-backend
 VERSION=${VERSION:-$(cat $BASEDIR/VERSION)}
 
-trap "docker-compose down -v" EXIT
+trap "docker-compose down -v --rmi" EXIT
 
 echo 'Building container and running CI'
-docker-compose run app bundle exec rails db:create ci
+docker-compose --project-name lighthouse-platform-backend-${BUILD_ID} run app bundle exec rails db:create ci
 
 echo 'Building production container...'
 docker build --pull -f $BASEDIR/Dockerfile -t $REPOSITORY:$VERSION $BASEDIR


### PR DESCRIPTION
This PR is an attempt to fix the issue of containers inside of Jenkins from using cached images. This will tag the images we create with the build number and make sure that the docker compose down removes the image.