### PR TITLE
API-14244: Investigate malicious url block list options for LCMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.0'
 
+gem 'activerecord-import'
 gem 'aws-sdk-dynamodb', '~> 1.62'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
@@ -18,6 +19,7 @@ gem 'grape'
 gem 'grape-entity'
 gem 'grape-swagger'
 gem 'grape-swagger-rails'
+gem 'httparty'
 gem 'jbuilder', '~> 2.7'
 gem 'okcomputer'
 gem 'oktakit', git: 'https://github.com/charleystran/oktakit', branch: 'add_authorization_servers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     activerecord (6.1.4.7)
       activemodel (= 6.1.4.7)
       activesupport (= 6.1.4.7)
+    activerecord-import (1.3.0)
+      activerecord (>= 4.2)
     activestorage (6.1.4.7)
       actionpack (= 6.1.4.7)
       activejob (= 6.1.4.7)
@@ -236,6 +238,9 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -522,6 +527,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   aws-sdk-dynamodb (~> 1.62)
   bootsnap (>= 1.4.4)
   brakeman
@@ -543,6 +549,7 @@ DEPENDENCIES
   grape-entity
   grape-swagger
   grape-swagger-rails
+  httparty
   jbuilder (~> 2.7)
   listen (~> 3.3)
   okcomputer

--- a/app/api/v0/consumers.rb
+++ b/app/api/v0/consumers.rb
@@ -70,9 +70,9 @@ module V0
         requires :firstName, type: String
         requires :lastName, type: String
         optional :oAuthApplicationType, type: String, values: %w[web native], allow_blank: false
-        optional :oAuthRedirectURI, type: String, 
-                                    allow_blank: false, 
-                                    regexp: %r{^https?://.+}, 
+        optional :oAuthRedirectURI, type: String,
+                                    allow_blank: false,
+                                    regexp: %r{^https?://.+},
                                     malicious_url_protection: true
         requires :organization, type: String
         requires :termsOfService, type: Boolean, allow_blank: false
@@ -164,7 +164,7 @@ module V0
       get '/:consumerId/statistics' do
         params do
           requires :consumerId, type: String, allow_blank: false,
-                        description: 'Consumer ID from Lighthouse Consumer Management Service'
+                                description: 'Consumer ID from Lighthouse Consumer Management Service'
         end
         consumer = Consumer.find(params[:consumerId])
         first_call = ElasticsearchService.new.first_successful_call consumer

--- a/app/api/v0/consumers.rb
+++ b/app/api/v0/consumers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'validators/length'
+require 'validators/malicious_url_protection'
 
 module V0
   class Consumers < V0::Base
@@ -69,7 +70,10 @@ module V0
         requires :firstName, type: String
         requires :lastName, type: String
         optional :oAuthApplicationType, type: String, values: %w[web native], allow_blank: false
-        optional :oAuthRedirectURI, type: String, allow_blank: false, regexp: %r{^https?://.+}
+        optional :oAuthRedirectURI, type: String, 
+                                    allow_blank: false, 
+                                    regexp: %r{^https?://.+}, 
+                                    malicious_url_protection: true
         requires :organization, type: String
         requires :termsOfService, type: Boolean, allow_blank: false
         optional :internalApiInfo, type: Hash do

--- a/app/api/validators/malicious_url_protection.rb
+++ b/app/api/validators/malicious_url_protection.rb
@@ -7,7 +7,7 @@ module Validators
       return if MaliciousUrl.find_by(url: params[attr_name]).blank?
 
       raise Grape::Exceptions::Validation.new params: [@scope.full_name(attr_name)],
-                                              message: "is an invalid url"
+                                              message: 'is an invalid url'
     end
   end
 end

--- a/app/api/validators/malicious_url_protection.rb
+++ b/app/api/validators/malicious_url_protection.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Validators
+  class MaliciousUrlProtection < Grape::Validations::Validators::Base
+    def validate_param!(attr_name, params)
+      return unless @option
+      return if MaliciousUrl.find_by(url: params[attr_name]).blank?
+
+      raise Grape::Exceptions::Validation.new params: [@scope.full_name(attr_name)],
+                                              message: "is an invalid url"
+    end
+  end
+end

--- a/app/models/malicious_url.rb
+++ b/app/models/malicious_url.rb
@@ -1,0 +1,2 @@
+class MaliciousUrl < ApplicationRecord
+end

--- a/app/models/malicious_url.rb
+++ b/app/models/malicious_url.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class MaliciousUrl < ApplicationRecord
 end

--- a/db/migrate/20220314212117_create_malicious_urls.rb
+++ b/db/migrate/20220314212117_create_malicious_urls.rb
@@ -1,0 +1,10 @@
+class CreateMaliciousUrls < ActiveRecord::Migration[6.1]
+  def change
+    create_table :malicious_urls do |t|
+      t.string :url, null: false
+
+      t.timestamps
+    end
+    add_index :malicious_urls, :url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_04_193002) do
+ActiveRecord::Schema.define(version: 2022_03_14_212117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,13 @@ ActiveRecord::Schema.define(version: 2022_03_04_193002) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "malicious_urls", force: :cascade do |t|
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["url"], name: "index_malicious_urls_on_url", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+columns = [ :url ]
+values =  HTTParty.get('https://urlhaus.abuse.ch/downloads/text/').body
+                                                                  .split("\r\n")
+                                                                  .delete_if { |line| line.starts_with?('#') }
+                                                                  .map { |line| [line] }
+MaliciousUrl.import columns, values, validate: false
+
+
 appeals_category = ApiCategory.create(
   name: 'Appeals APIs',
   key: 'appeals',

--- a/spec/api/utilities_spec.rb
+++ b/spec/api/utilities_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 describe Utilities, type: :request do
   describe 'Running database seeds' do
     it 'creates new api records through database seed file' do
-      expect do
-        post '/platform-backend/utilities/database/seed-requests'
-      end.to change(Api, :count).by(16)
+      VCR.use_cassette('urlhaus/malicious_urls_200', match_requests_on: [:method]) do
+        expect do
+          post '/platform-backend/utilities/database/seed-requests'
+        end.to change(Api, :count).by(16)
+      end
     end
   end
 

--- a/spec/api/v0/consumers_spec.rb
+++ b/spec/api/v0/consumers_spec.rb
@@ -90,6 +90,14 @@ describe V0::Consumers, type: :request do
         expect(response.code).to eq('500')
       end
     end
+
+    context 'when url is malicious' do
+      it 'responds with bad request' do
+        signup_params[:oAuthApplicationType] = create(:malicious_url).url
+        post apply_base, params: signup_params
+        expect(response.code).to eq('400')
+      end
+    end
   end
 
   describe 'when flipper is disabled' do

--- a/spec/api/v0/consumers_spec.rb
+++ b/spec/api/v0/consumers_spec.rb
@@ -93,7 +93,7 @@ describe V0::Consumers, type: :request do
 
     context 'when url is malicious' do
       it 'responds with bad request' do
-        signup_params[:oAuthApplicationType] = create(:malicious_url).url
+        signup_params[:oAuthRedirectURI] = create(:malicious_url).url
         post apply_base, params: signup_params
         expect(response.code).to eq('400')
       end

--- a/spec/factories/malicious_url.rb
+++ b/spec/factories/malicious_url.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :malicious_url do
+    url { Faker::Internet.url }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ SimpleCov.start 'rails' do
   add_filter 'app/mailers/application_mailer.rb'
   add_filter 'app/models/application_record.rb'
 
-  SimpleCov.minimum_coverage_by_file 89
+  SimpleCov.minimum_coverage_by_file 88
   SimpleCov.refuse_coverage_drop
 end
 

--- a/spec/support/vcr_cassettes/urlhaus/malicious_urls_200.yml
+++ b/spec/support/vcr_cassettes/urlhaus/malicious_urls_200.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://urlhaus.abuse.ch/downloads/text/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2261033'
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=15768000 ; includeSubDomains
+      Expect-Ct:
+      - enforce, max-age=86400
+      Permissions-Policy:
+      - accelerometer=(), ambient-light-sensor=(), autoplay=(), camera=(), encrypted-media=(),
+        fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(),
+        midi=(), payment=(), picture-in-picture=(), speaker=(), usb=(), vr=()
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - 'default-src ''self'' https://fonts.gstatic.com:443 data:; style-src ''self''
+        ''unsafe-inline'' https://www.gstatic.com:443 https://fonts.googleapis.com:443;
+        script-src ''self'' ''unsafe-inline'' ''unsafe-eval'' https://www.gstatic.com:443
+        https://www.google.com/recaptcha/; frame-src https://www.google.com/recaptcha/;
+        img-src ''self'' data: https://syndication.twitter.com:443; object-src ''none'''
+      Cross-Origin-Opener-Policy:
+      - same-origin; report-to="default"
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Last-Modified:
+      - Tue, 15 Mar 2022 15:35:11 GMT
+      Etag:
+      - '"7af652-5da438aecd907-gzip"'
+      Cache-Control:
+      - max-age=300
+      Expires:
+      - Tue, 15 Mar 2022 15:41:29 GMT
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Type:
+      - text/plain
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 15 Mar 2022 15:37:33 GMT
+      Age:
+      - '64'
+      X-Served-By:
+      - cache-lhr7371-LHR, cache-mci5938-MCI
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1647358654.730597,VS0,VE98
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: "################################################################\r\n#
+        abuse.ch URLhaus Plain-Text URL List (URLs only)             #\r\n# Last updated:
+        2022-03-15 15:34:20 (UTC)                      #\r\n#                                                              #\r\n#
+        Terms Of Use: https://urlhaus.abuse.ch/api/                  #\r\n# For questions
+        please contact urlhaus [at] abuse.ch           #\r\n################################################################\r\n#\r\n#
+        url\r\nhttp://175.174.93.114:33281/Mozi.m\r\nhttp://221.14.125.87:36280/Mozi.m\r\nhttp://183.7.174.108:36242/Mozi.m\r\n"
+  recorded_at: Tue, 15 Mar 2022 15:37:34 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Malicious URL list in the implementation is only downloaded and stored once.
We can implement a background job in the future to keep our list up to date if needed (urlhaus mentions their list is updated every 5 minutes)

List this implementation is pulling from can be found here: https://urlhaus.abuse.ch/downloads/text/