### PR TITLE
ignore duplicate malicious urls

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ values =  HTTParty.get('https://urlhaus.abuse.ch/downloads/text/').body
                                                                   .split("\r\n")
                                                                   .delete_if { |line| line.starts_with?('#') }
                                                                   .map { |line| [line] }
-MaliciousUrl.import columns, values, validate: false
+MaliciousUrl.import columns, values, validate: false, on_duplicate_key_ignore: true
 
 
 appeals_category = ApiCategory.create(


### PR DESCRIPTION
Allows re-running of this without first deleting all existing data in the database.

https://github.com/zdennis/activerecord-import/#duplicate-key-ignore