### PR TITLE
decode release notes from release notes repo

### DIFF
--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -56,7 +56,7 @@ module V0
           api_metadatum = Api.kept.find_by!(name: params[:providerName]).api_metadatum
           release_note = ApiReleaseNote.create(api_metadatum_id: api_metadatum.id,
                                                date: params[:date],
-                                               content: params[:content])
+                                               content: CGI.unescape(params[:content]))
 
           present release_note, with: V0::Entities::ApiReleaseNoteEntity, base_url: request.base_url
         end


### PR DESCRIPTION
Release notes sent from release notes repo are url encoded to prevent issues with quotation marks, etc. LCMS needs to decode the release note content string before storing.