### PR TITLE
fixes 400 on update_policy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,6 +103,9 @@ Metrics/MethodLength:
 Metrics/CyclomaticComplexity:
   IgnoredMethods:
     - 'consumer_signup'
+Metrics/PerceivedComplexity:
+  IgnoredMethods:
+    - 'consumer_signup'
 Rails:
   Enabled: true
 

--- a/app/services/okta/base_service.rb
+++ b/app/services/okta/base_service.rb
@@ -35,7 +35,8 @@ module Okta
         raise "No default policy for clientId: #{client_id}, authServerId: #{auth_server_id}" if default_policy.blank?
 
         default_policy.conditions.clients.include.push(client_id)
-        @client.update_authorization_server_policy(auth_server_id, default_policy.id, default_policy)
+        @client.update_authorization_server_policy(auth_server_id, default_policy.id, default_policy.to_h)
+        raise "Okta failed to add clientId: #{client_id} to policy: #{default_policy.id}" unless status_code == 200
       end
 
       application


### PR DESCRIPTION
Corrects the 400 from sending in a sawyer resource. This will be needed even with the upcoming Oktakit changes. 

Interesting to test. Have to create an auth server and provide that auth_server_access_key. Then overwrite the default `ALL_CLIENTS` in the `conditions.clients.include` and THEN apply through LPB.

Steps:
Create Auth Server
Use Oktakit to update Auth Server Default policy. -> Remove `ALL_CLIENTS` (I added an application ID just to mock) Without removing the `ALL_CLIENTS` it simply stayed `ALL_CLIENTS` even after signup.
Add Auth Server ID to `application.yml` to whatever oauth API you'll be signing up for (I used `verification` ApiRef)
Apply through LPB