### PR TITLE
claims is only oauth in DPB for sandbox signup

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -197,9 +197,7 @@ decision_reviews_api.update(
 )
 
 claims_api = Api.create(name: 'claims')
-claims_api.update(
-  acl: 'claims',
-  auth_server_access_key: 'AUTHZ_SERVER_CLAIMS',
+claims_api.update(  auth_server_access_key: 'AUTHZ_SERVER_CLAIMS',
   api_environments_attributes: {
    metadata_url: 'https://api.va.gov/internal/docs/benefits-claims/metadata.json',
    environments_attributes: {


### PR DESCRIPTION
Email from signing up in dev-developer.va.gov
- from DPB: only provides oauth information
- from LPB: provides both api key information as well as oauth information

This should make it so signups to Benefits Claims in sandbox are only for the oauth implementation. Which makes sense considering v0 (the version that uses apikey) is deprecated and going away.