### PR TITLE
client id in response is not what developer-portal expects

### DIFF
--- a/app/api/v0/entities/consumer_application_entity.rb
+++ b/app/api/v0/entities/consumer_application_entity.rb
@@ -7,7 +7,7 @@ module V0
         user.consumer.apis_list.map(&:api_ref).map(&:name).join(',')
       end
 
-      expose :clientId, documentation: { type: String } do |_user, options|
+      expose :clientID, documentation: { type: String } do |_user, options|
         options.dig(:okta_consumers, :acg, :credentials, :oauthClient, :client_id)
       end
 


### PR DESCRIPTION
This issue was causing the developer-portal frontend to not display oauth information on the sandbox signup success page.