### PR TITLE
API-11956/additional-tweaks

### DIFF
--- a/app/api/v0/entities/legacy/api_provider_category_entity.rb
+++ b/app/api/v0/entities/legacy/api_provider_category_entity.rb
@@ -6,7 +6,9 @@ module V0
       class ApiProviderCategoryEntity < Grape::Entity
         expose :name, documentation: { type: String }
         expose :name, as: :properName, documentation: { type: String }
-        expose :api_metadatum, as: :apis, using: V0::Entities::Legacy::ApiProviderEntity
+        expose :api_metadatum, as: :apis do |entity, options|
+          V0::Entities::Legacy::ApiProviderEntity.represent(entity.api_metadatum, environment: options[:environment])
+        end
         expose :content do |entity|
           response = { consumerDocsLinkText: entity.consumer_docs_link_text,
                        shortDescription: entity.short_description,

--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -35,9 +35,9 @@ module V0
       end
       get '/transformations/legacy' do
         categories = {}
-        ApiCategory.kept.each do |category|
+        ApiCategory.kept.order(:name).each do |category|
           categories[category.key] =
-            V0::Entities::Legacy::ApiProviderCategoryEntity.represent(category)
+            V0::Entities::Legacy::ApiProviderCategoryEntity.represent(category, environment: params[:environment])
         end
 
         categories


### PR DESCRIPTION
pass environment option through to the entity that cares about it
this allows picking an environment on api request, which allows the portal to get only one metadata url back in the providers response

also realized categories on the left sidebar wasnt being sorted by name