### PR TITLE
Add provider endpoint

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -431,6 +431,38 @@ veteran_confirmation_api.update(
   }
 )
 
+veteran_letter_generator_api = Api.create(name: 'veteran-letters')
+veteran_letter_generator_api.update(
+  auth_server_access_key: 'TBD',
+  api_environments_attributes: {
+    metadata_url: 'https://api.va.gov/internal/docs/veteran-letters/metadata.json',
+    environments_attributes: {
+      name: ['sandbox', 'production']
+    }
+  },
+  api_ref_attributes: {
+   name: 'vaLetterGenerator'
+  },
+  api_metadatum_attributes: {
+   description: 'Generate documents and letters for proof of existing VA benefits and status.',
+   display_name: 'VA Letter Generator API',
+   open_data: false,
+   va_internal_only: true,
+   url_fragment: 'va_letter_generator',
+   oauth_info: {
+      ccgInfo: {
+        baseAuthPath: '/oauth2/veteran-letters/system/v1',
+        productionAud: 'TBD',
+        sandboxAud: 'TBD',
+        scopes: ['letters.read'],
+      },
+    }.to_json,
+   api_category_attributes: {
+     id: veteran_verification_category.id
+   }
+  }
+)
+
 veteran_verification_api = Api.create(name: 'veteran-verification')
 veteran_verification_api.update(
   auth_server_access_key: 'AUTHZ_SERVER_VERIFICATION',

--- a/spec/api/v0/providers_spec.rb
+++ b/spec/api/v0/providers_spec.rb
@@ -55,6 +55,26 @@ describe V0::Providers, type: :request do
       expect(response.code).to eq('404')
     end
   end
+  
+  describe 'allows posts to create providers' do
+    let(:provider)  { build(:provider) }
+    before do
+      create(:api_category)
+    end
+    it 'creates a valid API' do
+      expect do
+        post '/platform-backend/v0/providers', params: provider
+        expect(response.status).to eq(201)
+      end.to change(Api, :count).by 1
+    end
+    
+    it 'provides an error when supplied invalid information' do
+      provider['name'] = ''
+      post '/platform-backend/v0/providers', params: provider
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)['errors'].length).to eq(1)
+    end
+  end
 
   describe 'enforces auth for non dev portal routes' do
     before do

--- a/spec/api/v0/providers_spec.rb
+++ b/spec/api/v0/providers_spec.rb
@@ -55,19 +55,21 @@ describe V0::Providers, type: :request do
       expect(response.code).to eq('404')
     end
   end
-  
+
   describe 'allows posts to create providers' do
-    let(:provider)  { build(:provider) }
+    let(:provider) { build(:provider) }
+
     before do
       create(:api_category)
     end
+
     it 'creates a valid API' do
       expect do
         post '/platform-backend/v0/providers', params: provider
         expect(response.status).to eq(201)
       end.to change(Api, :count).by 1
     end
-    
+
     it 'provides an error when supplied invalid information' do
       provider['name'] = ''
       post '/platform-backend/v0/providers', params: provider

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :provider, class: Hash do
+    name { Faker::Lorem.word }
+    auth_server_access_key { Faker::Lorem.word }
+    api_environments_attributes do
+      {
+        metadata_url: Faker::Internet.domain_name,
+        environments_attributes: {
+          name: 'sandbox,production'
+        }
+      }
+    end
+    api_ref_attributes do
+      {
+        name: Faker::Lorem.word
+      }
+    end
+    api_metadatum_attributes do
+      {
+        description: Faker::Lorem.sentence(word_count: 12),
+        display_name: Faker::Lorem.sentence(word_count: 4),
+        open_data: Faker::Boolean.boolean,
+        va_internal_only: Faker::Boolean.boolean,
+        url_fragment: Faker::Lorem.word,
+        oauth_info: {
+          ccgInfo: {
+            baseAuthPath: Faker::Internet.domain_name,
+            productionAud: Faker::Lorem.word,
+            sandboxAud: Faker::Lorem.word,
+            scopes: 'test.true,test.false'
+          },
+          acgInfo: {
+            baseAuthPath: Faker::Internet.domain_name,
+            scopes: 'test.true,test.false'
+          }
+        },
+        api_category_attributes: {
+          id: ApiCategory.first.id || nil,
+        }
+      }
+    end
+
+    initialize_with { attributes }
+  end
+end

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
           }
         },
         api_category_attributes: {
-          id: ApiCategory.first.id || nil,
+          id: ApiCategory.first.id || nil
         }
       }
     end


### PR DESCRIPTION
to make this work with grape-swagger as well as a default postman request, the two array types had to be comma-delimited and use a `coerce_with` to modify a string to an array.