### PR TITLE
prevent multiple drift jobs

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,5 +7,6 @@ class Event < ApplicationRecord
   EVENT_TYPES = { sandbox_signup: 'sandbox_signup',
                   weekly_report: 'weekly_signups_report',
                   monthly_report: 'monthly_signups_report',
-                  lpb_signup: 'lpb_signup' }.freeze
+                  lpb_signup: 'lpb_signup',
+                  drift_job: 'drift_job' }.freeze
 end

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -5,8 +5,11 @@ require 'rufus-scheduler'
 s = Rufus::Scheduler.singleton
 
 s.cron '0 2 * * *' do
+  BackgroundJobEnforcer.create(job_type: Event::EVENT_TYPES[:drift_job], date: Time.zone.today)
   OktaDriftJob.perform_now
   KongDriftJob.perform_now
+rescue ActiveRecord::RecordNotUnique
+  # ignore, its already being handled
 end
 
 s.cron '0 11 * * 1' do


### PR DESCRIPTION
Prevents multiple drift jobs from being sent to Slack via the multiple containers.