### PR TITLE
API-17549: enable utilities endpoints on-demand

### DIFF
--- a/app/services/okta/base_service.rb
+++ b/app/services/okta/base_service.rb
@@ -134,7 +134,7 @@ module Okta
       app = application.to_h
       summary = app[:errorSummary]
       cause = app[:errorCauses]&.first&.dig(:errorSummary)
-      response_cause = " - #{cause}" unless cause.blank?
+      response_cause = " - #{cause}" if cause.present?
       summary + (response_cause || '')
     end
 

--- a/spec/api/utilities_spec.rb
+++ b/spec/api/utilities_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 describe Utilities, type: :request do
+  before do
+    Flipper.enable :enable_utilities
+  end
+
+  after do
+    Flipper.disable :enable_utilities
+  end
+
   describe 'APIs' do
     before do
       create(:api, :with_api_environment)


### PR DESCRIPTION
Working with backstage, it provides swagger-ui for free.
The problem is the utilities endpoints are shown there and can be interacted with without being locked down to our team in production.
This is the best solution I could come up with. It means we will have to enable the utilities endpoints when we need to use them and disable them (also hides them from the openapi spec) when theyre not in use.

I tried to tie showing or hiding the endpoints to the signed in user, but I couldn't get access to the current_user (or the request at all) at the stage where hiding needed to be determined.