### PR TITLE
[API-18379] - Persist "ProductionRequest" form data

### DIFF
--- a/app/api/v0/consumers.rb
+++ b/app/api/v0/consumers.rb
@@ -9,6 +9,7 @@ module V0
   class Consumers < V0::Base
     version 'v0'
 
+    helpers ProductionRequestHelper
     helpers do
       def user_from_signup_params
         users = User.where('LOWER(email) = ?', params[:email].downcase.strip)
@@ -222,6 +223,11 @@ module V0
         header 'Access-Control-Allow-Origin', request.host_with_port
         protect_from_forgery
 
+        begin
+          create_production_request_record!(params: params)
+        rescue
+          # just in-case... don't want to disrupt the existing workflow
+        end
         send_production_access_emails(params) if Flipper.enabled? :send_emails
 
         body false

--- a/app/helpers/production_request_helper.rb
+++ b/app/helpers/production_request_helper.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module ProductionRequestHelper
+  def build_api_references(apis:)
+    ApiService.parse(apis, filter_lpb: true)
+  end
+
+  def extract_status_update_emails(status_update_emails_param:)
+    status_update_emails_param.join(',')
+  end
+
+  def build_contact_reference(contact_info:, contact_type:)
+    email = contact_info[:email]
+    first_name = contact_info[:firstName]
+    last_name = contact_info[:lastName]
+
+    users = User.where('LOWER(email) = ?', email.downcase.strip)
+    user = users.present? ? users.first : User.new(email: email.strip)
+    user.first_name = first_name
+    user.last_name = last_name
+
+    ProductionRequestContact.new(user: user, contact_type: contact_type)
+  end
+
+  def extract_privacy_policy_url(policy_documents_param:)
+    return if policy_documents_param.blank?
+    return if policy_documents_param.second.blank?
+
+    policy_documents_param.second
+  end
+
+  def extract_sign_up_link_url(sign_up_link_param:)
+    return if sign_up_link_param.blank?
+
+    [sign_up_link_param].flatten.first
+  end
+
+  def extract_support_link_url(support_link_param:)
+    return if support_link_param.blank?
+
+    [support_link_param].flatten.first
+  end
+
+  def extract_terms_of_service_url(policy_documents_param:)
+    return if policy_documents_param.blank?
+
+    policy_documents_param.first
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  def create_production_request_record!(params:)
+    prod_req = ProductionRequest.new
+    prod_req.apis = build_api_references(apis: params[:apis])
+    prod_req.app_description = params[:appDescription]
+    prod_req.app_name = params[:appName]
+    prod_req.breach_management_process = params[:breachManagementProcess]
+    prod_req.business_model = params[:businessModel]
+    prod_req.centralized_backend_log = params[:centralizedBackendLog]
+    prod_req.distributing_api_keys_to_customers = params[:distributingAPIKeysToCustomers]
+    prod_req.expose_veteran_information_to_third_parties = params[:exposeVeteranInformationToThirdParties]
+    prod_req.is_508_compliant = params[:is508Compliant]
+    prod_req.listed_on_my_health_application = params[:listedOnMyHealthApplication]
+    prod_req.monitization_explanation = params[:monitizationExplanation]
+    prod_req.monitized_veteran_information = params[:monitizedVeteranInformation]
+    prod_req.multiple_req_safeguards = params[:multipleReqSafeguards]
+    prod_req.naming_convention = params[:namingConvention]
+    prod_req.organization = params[:organization]
+    prod_req.phone_number = params[:phoneNumber]
+    prod_req.pii_storage_method = params[:piiStorageMethod]
+    prod_req.platforms = params[:platforms]
+    prod_req.primary_contact = build_contact_reference(
+      contact_info: params[:primaryContact],
+      contact_type: 'primary'
+    )
+    prod_req.privacy_policy_url = extract_privacy_policy_url(policy_documents_param: params[:policyDocuments])
+    prod_req.production_key_credential_storage = params[:productionKeyCredentialStorage]
+    prod_req.production_or_oauth_key_credential_storage = params[:productionOrOAuthKeyCredentialStorage]
+    prod_req.secondary_contact = build_contact_reference(
+      contact_info: params[:secondaryContact],
+      contact_type: 'secondary'
+    )
+    prod_req.scopes_access_requested = params[:scopesAccessRequested]
+    prod_req.sign_up_link_url = extract_sign_up_link_url(sign_up_link_param: params[:signUpLink])
+    prod_req.status_update_emails = extract_status_update_emails(
+      status_update_emails_param: params[:statusUpdateEmails]
+    )
+    prod_req.store_pii_or_phi = params[:storePIIOrPHI]
+    prod_req.support_link_url = extract_support_link_url(support_link_param: params[:supportLink])
+    prod_req.terms_of_service_url = extract_terms_of_service_url(policy_documents_param: params[:policyDocuments])
+    prod_req.third_party_info_description = params[:thirdPartyInfoDescription]
+    prod_req.value_provided = params[:valueProvided]
+    prod_req.vasi_system_name = params[:vasiSystemName]
+    prod_req.veteran_facing = params[:veteranFacing]
+    prod_req.veteran_facing_description = params[:veteranFacingDescription]
+    prod_req.vulnerability_management = params[:vulnerabilityManagement]
+    prod_req.website = params[:website]
+    prod_req.save!
+  end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
+end

--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -17,6 +17,8 @@ class Api < ApplicationRecord
   has_one :api_ref, dependent: :destroy
   has_many :api_environments, dependent: :destroy
   has_one :api_metadatum, dependent: :destroy
+  has_many :apis_production_requests, dependent: :destroy
+  has_many :production_requests, through: :apis_production_requests
 
   scope :displayable, -> { joins(:api_metadatum) }
   scope :auth_type, lambda { |auth_type|

--- a/app/models/apis_production_request.rb
+++ b/app/models/apis_production_request.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ApisProductionRequest < ApplicationRecord
+  belongs_to :api
+  belongs_to :production_request
+end

--- a/app/models/production_request.rb
+++ b/app/models/production_request.rb
@@ -4,13 +4,11 @@ class ProductionRequest < ApplicationRecord
   has_many :apis_production_requests, dependent: :destroy
   has_many :apis, through: :apis_production_requests
   has_many :production_request_contacts, dependent: :destroy
-  has_one :primary_contact,
-          -> { where(contact_type: 'primary') },
+  has_one :primary_contact, -> { where(contact_type: 'primary') },
           class_name: 'ProductionRequestContact',
           inverse_of: :production_request,
           dependent: :destroy
-  has_one :secondary_contact,
-          -> { where(contact_type: 'secondary') },
+  has_one :secondary_contact, -> { where(contact_type: 'secondary') },
           class_name: 'ProductionRequestContact',
           inverse_of: :production_request,
           dependent: :destroy

--- a/app/models/production_request.rb
+++ b/app/models/production_request.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ProductionRequest < ApplicationRecord
+  has_many :apis_production_requests, dependent: :destroy
+  has_many :apis, through: :apis_production_requests
+  has_many :production_request_contacts, dependent: :destroy
+  has_one :primary_contact,
+          -> { where(contact_type: 'primary') },
+          class_name: 'ProductionRequestContact',
+          inverse_of: :production_request,
+          dependent: :destroy
+  has_one :secondary_contact,
+          -> { where(contact_type: 'secondary') },
+          class_name: 'ProductionRequestContact',
+          inverse_of: :production_request,
+          dependent: :destroy
+
+  validates :apis, presence: true
+  validates :organization, presence: true
+  validates :primary_contact, presence: true
+  validates :secondary_contact, presence: true
+  validates :status_update_emails, presence: true
+  validates :value_provided, presence: true
+end

--- a/app/models/production_request_contact.rb
+++ b/app/models/production_request_contact.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ProductionRequestContact < ApplicationRecord
+  belongs_to :production_request
+  belongs_to :user
+
+  enum contact_type: { primary: 0, secondary: 1 }
+end

--- a/db/migrate/20220928201902_create_production_requests.rb
+++ b/db/migrate/20220928201902_create_production_requests.rb
@@ -1,0 +1,41 @@
+class CreateProductionRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :production_requests, id: :uuid do |t|
+      t.text :app_description
+      t.string :app_name
+      t.text :breach_management_process
+      t.text :business_model
+      t.string :centralized_backend_log
+      t.boolean :distributing_api_keys_to_customers, default: false, null: false
+      t.boolean :expose_veteran_information_to_third_parties, default: false, null: false
+      t.boolean :is_508_compliant, default: false, null: false
+      t.boolean :listed_on_my_health_application, default: false, null: false
+      t.text :monitization_explanation
+      t.boolean :monitized_veteran_information, default: false, null: false
+      t.text :multiple_req_safeguards
+      t.string :naming_convention
+      t.string :organization
+      t.string :phone_number
+      t.text :pii_storage_method
+      t.string :platforms
+      t.string :privacy_policy_url
+      t.text :production_key_credential_storage
+      t.text :production_or_oauth_key_credential_storage
+      t.text :scopes_access_requested
+      t.string :sign_up_link_url
+      t.string :status_update_emails
+      t.boolean :store_pii_or_phi, default: false, null: false
+      t.string :support_link_url
+      t.string :terms_of_service_url
+      t.text :third_party_info_description
+      t.text :value_provided
+      t.string :vasi_system_name
+      t.boolean :veteran_facing, default: false, null: false
+      t.text :veteran_facing_description
+      t.text :vulnerability_management
+      t.string :website
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220928204902_create_apis_production_requests.rb
+++ b/db/migrate/20220928204902_create_apis_production_requests.rb
@@ -1,0 +1,10 @@
+class CreateApisProductionRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :apis_production_requests, id: :uuid do |t|
+      t.references :api, null: false, foreign_key: true, type: :bigint
+      t.references :production_request, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220930124413_create_production_request_contacts.rb
+++ b/db/migrate/20220930124413_create_production_request_contacts.rb
@@ -1,0 +1,11 @@
+class CreateProductionRequestContacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :production_request_contacts, id: :uuid do |t|
+      t.references :production_request, null: false, foreign_key: true, type: :uuid
+      t.references :user, null: false, foreign_key: true, type: :bigint
+      t.integer :contact_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_194252) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_30_124413) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,6 +91,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_194252) do
     t.string "auth_server_access_key"
     t.index ["discarded_at"], name: "index_apis_on_discarded_at"
     t.index ["name"], name: "index_apis_on_name", unique: true
+  end
+
+  create_table "apis_production_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "api_id", null: false
+    t.uuid "production_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_id"], name: "index_apis_production_requests_on_api_id"
+    t.index ["production_request_id"], name: "index_apis_production_requests_on_production_request_id"
   end
 
   create_table "background_job_enforcers", force: :cascade do |t|
@@ -176,6 +185,54 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_194252) do
     t.index ["url"], name: "index_malicious_urls_on_url", unique: true
   end
 
+  create_table "production_request_contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "production_request_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "contact_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["production_request_id"], name: "index_production_request_contacts_on_production_request_id"
+    t.index ["user_id"], name: "index_production_request_contacts_on_user_id"
+  end
+
+  create_table "production_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "app_description"
+    t.string "app_name"
+    t.text "breach_management_process"
+    t.text "business_model"
+    t.string "centralized_backend_log"
+    t.boolean "distributing_api_keys_to_customers", default: false, null: false
+    t.boolean "expose_veteran_information_to_third_parties", default: false, null: false
+    t.boolean "is_508_compliant", default: false, null: false
+    t.boolean "listed_on_my_health_application", default: false, null: false
+    t.text "monitization_explanation"
+    t.boolean "monitized_veteran_information", default: false, null: false
+    t.text "multiple_req_safeguards"
+    t.string "naming_convention"
+    t.string "organization"
+    t.string "phone_number"
+    t.text "pii_storage_method"
+    t.string "platforms"
+    t.string "privacy_policy_url"
+    t.text "production_key_credential_storage"
+    t.text "production_or_oauth_key_credential_storage"
+    t.text "scopes_access_requested"
+    t.string "sign_up_link_url"
+    t.string "status_update_emails"
+    t.boolean "store_pii_or_phi", default: false, null: false
+    t.string "support_link_url"
+    t.string "terms_of_service_url"
+    t.text "third_party_info_description"
+    t.text "value_provided"
+    t.string "vasi_system_name"
+    t.boolean "veteran_facing", default: false, null: false
+    t.text "veteran_facing_description"
+    t.text "vulnerability_management"
+    t.string "website"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -201,7 +258,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_194252) do
   add_foreign_key "api_metadata", "apis"
   add_foreign_key "api_refs", "apis"
   add_foreign_key "api_release_notes", "api_metadata"
+  add_foreign_key "apis_production_requests", "apis"
+  add_foreign_key "apis_production_requests", "production_requests"
   add_foreign_key "consumer_api_assignments", "consumers"
   add_foreign_key "consumer_auth_refs", "consumers"
   add_foreign_key "consumers", "users"
+  add_foreign_key "production_request_contacts", "production_requests"
+  add_foreign_key "production_request_contacts", "users"
 end

--- a/spec/models/production_request_spec.rb
+++ b/spec/models/production_request_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProductionRequest, type: :model do
+  subject do
+    ProductionRequest.new(
+      apis: [create(:api)],
+      app_description: Faker::Hipster.word,
+      app_name: Faker::Hipster.word,
+      breach_management_process: Faker::Hipster.word,
+      business_model: Faker::Hipster.word,
+      centralized_backend_log: Faker::Hipster.word,
+      distributing_api_keys_to_customers: false,
+      expose_veteran_information_to_third_parties: false,
+      is_508_compliant: true,
+      listed_on_my_health_application: false,
+      monitization_explanation: Faker::Hipster.word,
+      monitized_veteran_information: Faker::Hipster.word,
+      multiple_req_safeguards: Faker::Hipster.word,
+      naming_convention: Faker::Hipster.word,
+      organization: Faker::Hipster.word,
+      phone_number: '(555) 555-5555',
+      pii_storage_method: Faker::Hipster.word,
+      platforms: Faker::Hipster.word,
+      primary_contact: primary_contact,
+      privacy_policy_url: Faker::Internet.url,
+      production_key_credential_storage: Faker::Hipster.word,
+      production_or_oauth_key_credential_storage: Faker::Hipster.word,
+      scopes_access_requested: Faker::Hipster.word,
+      secondary_contact: secondary_contact,
+      sign_up_link_url: Faker::Internet.url,
+      status_update_emails: [Faker::Internet.safe_email],
+      store_pii_or_phi: false,
+      support_link_url: Faker::Internet.url,
+      terms_of_service_url: Faker::Internet.url,
+      third_party_info_description: Faker::Hipster.word,
+      value_provided: Faker::Hipster.word,
+      vasi_system_name: Faker::Hipster.word,
+      veteran_facing: true,
+      veteran_facing_description: Faker::Hipster.word,
+      vulnerability_management: Faker::Hipster.word,
+      website: Faker::Internet.url
+    )
+  end
+
+  let(:user_1) { create(:user) }
+  let(:primary_contact) { ProductionRequestContact.new(user: user_1, contact_type: 'primary') }
+
+  let(:user_2) { create(:user) }
+  let(:secondary_contact) { ProductionRequestContact.new(user: user_2, contact_type: 'secondary') }
+
+  describe 'tests a valid ProductionRequest model' do
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+  end
+
+  describe 'tests an invalid ProductionRequest model' do
+    it "is invalid without an 'apis' attribute" do
+      subject.apis = []
+      expect(subject).not_to be_valid
+    end
+
+    it "is invalid without an 'organization' attribute" do
+      subject.organization = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is invalid without a 'primary_contact' association" do
+      subject.primary_contact = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is invalid without a 'secondary_contact' association" do
+      subject.secondary_contact = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is invalid without a 'status_update_emails' attribute" do
+      subject.status_update_emails = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "is invalid without a 'value_provided' attribute" do
+      subject.value_provided = nil
+      expect(subject).not_to be_valid
+    end
+  end
+end

--- a/spec/models/production_request_spec.rb
+++ b/spec/models/production_request_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe ProductionRequest, type: :model do
     it 'is valid' do
       expect(subject).to be_valid
     end
+
+    it "has a 'primary_contact'" do
+      expect(subject.primary_contact.user.email).to eq(user_1.email)
+    end
+
+    it "has a 'secondary_contact'" do
+      expect(subject.secondary_contact.user.email).to eq(user_2.email)
+    end
   end
 
   describe 'tests an invalid ProductionRequest model' do


### PR DESCRIPTION
- provides the ability to store off data sent to the `/platform-backend/v0/consumers/production-requests` endpoint.