### PR TITLE
[API-21296] Update field descriptions to make it more clear

### DIFF
--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -77,7 +77,7 @@ module V0
       desc 'Add an API to the developer portal' do
         detail <<-detailText
           # Environment and Scopes
-          These fields are CSV ignore what the placeholder text from the textarea says, it's wrong.
+          These fields are CSV. Ignore what the placeholder text from the textarea says. It's wrong.
 
           # Sample values (New Demo API)
           ## Basic details

--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -81,7 +81,7 @@ module V0
                                   description: 'Metadata URL typically served by Docserver'
           requires :environments_attributes, type: Hash do
             requires :name, type: Array[String], allow_blank: false,
-                            description: 'Environments API is available within - comma separated',
+                            description: 'Available API Environments<br /><h2>Comma separated!<h2>',
                             values: ->(v) { %w[sandbox production].include?(v) },
                             coerce_with: ->(v) { v.split(',') }
           end
@@ -100,7 +100,7 @@ module V0
                                   description: 'Displayed Name for the Developer Portal'
           requires :open_data, type: Boolean, allow_blank: false, default: false
           requires :va_internal_only, type: String,
-                                      values: %w[StrictlyInternal AdditionalDetails FlagOnly],
+                                      values: ['StrictlyInternal', 'AdditionalDetails', 'FlagOnly', ''],
                                       allow_blank: true
           requires :url_fragment, type: String, allow_blank: false,
                                   description: 'URL fragment'
@@ -110,7 +110,7 @@ module V0
               optional :productionAud, type: String, allow_blank: true
               optional :sandboxAud, type: String, allow_blank: true
               optional :scopes, type: Array[String], allow_blank: false,
-                                description: 'Scopes available - comma separated',
+                                description: 'Scopes available<br /><h2>Comma separated!<h2>',
                                 coerce_with: lambda { |v|
                                                v.split(',')
                                              }
@@ -118,7 +118,7 @@ module V0
             optional :acgInfo, type: Hash do
               optional :baseAuthPath, type: String, allow_blank: false
               optional :scopes, type: Array[String], allow_blank: false,
-                                description: 'Scopes available - comma separated',
+                                description: 'Scopes available<br /><h2>Comma separated!<h2>',
                                 coerce_with: lambda { |v|
                                   v.split(',')
                                 }


### PR DESCRIPTION
Despite my best efforts to make the Swagger placeholder text actually accurate, the end result was to give more emphasis on these fields needing to be comma separated. Not happy with this solution but based on research it seems this is not something that has been solved.

The root issue is that with using multiple lines, when you post sandbox and production the `api_environments_attributes[environments_attributes][name]` field it will show up twice without a trailing `[]` on it causing the backend to only receive the last value.

```
api_environments_attributes[environments_attributes][name]: sandbox
api_environments_attributes[environments_attributes][name]: production
```