### PR TITLE
[API-14772] - Add additional GHA workflows for handling in-progress MR's

### DIFF
--- a/.github/workflows/pr-add-labels.yml
+++ b/.github/workflows/pr-add-labels.yml
@@ -1,0 +1,33 @@
+name: Pull Request Add Labels
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add_mr_in_progress_label_if_necessary:
+    runs-on: ubuntu-latest
+    steps:
+      - id: check_for_existing_mr
+        name: Check for existing MRs
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          gh issue list \
+            -R 'department-of-veterans-affairs/lighthouse-platform-backend' \
+            -l 'repo: lighthouse-platform-backend' \
+            --limit 1 \
+            --json id,number,state,labels,title \
+            > issue.json
+          cat issue.json
+          if [ "[]" == "$(cat issue.json)" ]; then
+            echo "mr_exists='false'" >> $GITHUB_OUTPUT
+          else
+            # there is an actve Maintenance Request (MR)
+            echo "mr_exists='true'" >> $GITHUB_OUTPUT
+          fi
+      - id: add_mr_in_progress_label
+        name: Add MR in progress label
+        if: steps.check_for_existing_mr.outputs.mr_exists == 'true'
+        run: |
+          PR_NUMBER=`echo ${{ github.event.pull_request.number }}`
+          echo "Adding MR in progress label to PR# $PR_NUMBER"
+          gh pr edit $PR_NUMBER --add-label "MR in progress"`

--- a/.github/workflows/pr-must-not-have-label.yml
+++ b/.github/workflows/pr-must-not-have-label.yml
@@ -1,0 +1,20 @@
+name: Pull Request Must Not Have Label
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+  workflow_run:
+    workflows: ['Pull Request Add Labels']
+    types:
+      - completed
+
+jobs:
+  is_labeled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: exactly
+          count: 0
+          labels: 'MR in progress'


### PR DESCRIPTION
Original Issue:: [API-14772](https://vajira.max.gov/browse/API-14772)

This PR aims to add GitHub Action (GHA) workflows that ::
- when a PR is opened, it will check to see if there is an active LPB Maintenance Request (MR).  If there is, add a `MR in progress` label to the PR.
- disables the "Merge" functionality when a PR has the `MR in progress` label.


**Notes**
- [PR# 232](https://github.com/department-of-veterans-affairs/lighthouse-platform-backend/pull/232) will come in behind this PR and change the `department-of-veterans-affairs/lighthouse-platform-backend` value to `department-of-veterans-affairs/lighthouse-devops-support` when we're ready to officially turn on auto deploys.
- When we are ready to officially turn on auto deploys, we'll need to go into the `lighthouse-devops-support` repo and create the following labels ::
  - `repo: lighthouse-platform-backend`
  - `MR in progress`