### PR TITLE
[API-14772] - add logic to re-login with the devops creds

### DIFF
--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -35,8 +35,6 @@ jobs:
       - id: create_mr
         name: Generate the MR body text and create MR
         if: steps.check_for_existing_mr.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           wget https://raw.githubusercontent.com/department-of-veterans-affairs/lighthouse-platform-backend/master/.github/workflows/assets/maintenance-request.md
           TEMPLATE_ISSUE_LABEL=`grep labels maintenance-request.md | cut -f2 -d " "`
@@ -79,6 +77,7 @@ jobs:
           cat maintenance-request.md
 
           echo "Create issue"
+          echo ${{ secrets.GIT_AUTO_DEPLOY_TOKEN }} | gh auth login --with-token
           gh issue create \
             -R 'department-of-veterans-affairs/lighthouse-devops-support' \
             --title "$ISSUE_TITLE" \


### PR DESCRIPTION
[Original Issue](https://vajira.max.gov/browse/API-14772)

When we first tried to run the auto-deploy workflows against the DevOps repo, we encountered the following error in the `create_mr` step of the `Create Auto Deploy Maintenance Request` workflow ::
```
GraphQL: Could not resolve to a Repository with the name 'department-of-veterans-affairs/lighthouse-devops-support'. (repository)
```

Looks like we might need to re-login using the DevOps github creds  in that step.  This PR adds that re-login functionality.