### PR TITLE
[API-14772] - Fix PR label add/remove GHA steps

### DIFF
--- a/.github/workflows/auto-deploy-to-production.yml
+++ b/.github/workflows/auto-deploy-to-production.yml
@@ -139,6 +139,7 @@ jobs:
         name: Remove MR in progress label from existing PRs
         if: steps.update_mr.outcome == 'success'
         run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           prNums=$(gh pr list -R 'department-of-veterans-affairs/lighthouse-platform-backend' --json number --jq '.[] | .number')
           for num in ${prNums[@]}; do
             gh pr edit $num -R 'department-of-veterans-affairs/lighthouse-platform-backend' --remove-label "MR in progress"

--- a/.github/workflows/create-auto-deploy-maintenance-request.yml
+++ b/.github/workflows/create-auto-deploy-maintenance-request.yml
@@ -89,6 +89,7 @@ jobs:
         name: Add MR in progress label to existing PRs
         if: steps.create_mr.outcome == 'success'
         run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           prNums=$(gh pr list -R 'department-of-veterans-affairs/lighthouse-platform-backend' --json number --jq '.[] | .number')
           for num in ${prNums[@]}; do
             gh pr edit $num -R 'department-of-veterans-affairs/lighthouse-platform-backend' --add-label "MR in progress"


### PR DESCRIPTION
[Original Issue](https://vajira.max.gov/browse/API-14772)

On the initial run of the auto deploy workflows, we ran into this error when attempting to add or remove labels from existing PRs.
```
Message: va-bot does not have the correct permissions to execute `RemoveLabelsFromLabelable`, Locations: [{Line:1 Column:62}]
```

This PR adds logic to explicitly authenticate to the GitHub cli as the non va-bot user.