### PR TITLE
[API-22785] - Add well known configs

### DIFF
--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -200,13 +200,13 @@ module V0
             end
             optional :acgInfo, type: Hash do
               optional :baseAuthPath, type: String, allow_blank: false
+              optional :productionWellKnownConfig, type: String, allow_blank: true
+              optional :sandboxWellKnownConfig, type: String, allow_blank: true
               optional :scopes, type: Array[String], allow_blank: false,
                                 description: 'Scopes available<br /><h2>Comma separated!<h2>',
                                 coerce_with: lambda { |v|
                                   v.split(',')
                                 }
-              optional :productionWellKnownConfig, type: String, allow_blank: true
-              optional :sandboxWellKnownConfig, type: String, allow_blank: true
             end
           end
           optional :veteran_redirect, type: Hash do

--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -189,13 +189,14 @@ module V0
             optional :ccgInfo, type: Hash do
               optional :baseAuthPath, type: String, allow_blank: false
               optional :productionAud, type: String, allow_blank: true
+              optional :productionWellKnownConfig, type: String, allow_blank: true
               optional :sandboxAud, type: String, allow_blank: true
+              optional :sandboxWellKnownConfig, type: String, allow_blank: true
               optional :scopes, type: Array[String], allow_blank: false,
                                 description: 'Scopes available<br /><h2>Comma separated!<h2>',
                                 coerce_with: lambda { |v|
                                                v.split(',')
                                              }
-              optional :wellKnownConfig, type: String, allow_blank: true
             end
             optional :acgInfo, type: Hash do
               optional :baseAuthPath, type: String, allow_blank: false
@@ -204,7 +205,8 @@ module V0
                                 coerce_with: lambda { |v|
                                   v.split(',')
                                 }
-              optional :wellKnownConfig, type: String, allow_blank: true
+              optional :productionWellKnownConfig, type: String, allow_blank: true
+              optional :sandboxWellKnownConfig, type: String, allow_blank: true
             end
           end
           optional :veteran_redirect, type: Hash do

--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -195,6 +195,7 @@ module V0
                                 coerce_with: lambda { |v|
                                                v.split(',')
                                              }
+              optional :wellKnownConfig, type: String, allow_blank: true
             end
             optional :acgInfo, type: Hash do
               optional :baseAuthPath, type: String, allow_blank: false
@@ -203,6 +204,7 @@ module V0
                                 coerce_with: lambda { |v|
                                   v.split(',')
                                 }
+              optional :wellKnownConfig, type: String, allow_blank: true
             end
           end
           optional :veteran_redirect, type: Hash do

--- a/app/api/v0/providers.rb
+++ b/app/api/v0/providers.rb
@@ -116,6 +116,8 @@ module V0
           - From the .well-known openid-configuration
           - https://api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration
           - https://sandbox-api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration
+          - When on prod, all values except for productionAud and productionWellKnownConfig should come
+            from the sandbox .well-known config file
 
           api_metadatum_attributes[oauth_info][ccgInfo][baseAuthPath]: /oauth2/claims/system/v1
           - Remove the domain from the front and /token from the end of token_endpoint
@@ -125,20 +127,35 @@ module V0
           - Last url segment taken from the issuer property
           - 'https://va.okta.com/oauth2/ausajojxqhTsDSVlA297' -> 'ausajojxqhTsDSVlA297'
 
+          api_metadatum_attributes[oauth_info][ccgInfo][productionWellKnownConfig]:
+          - https://api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration
+
           api_metadatum_attributes[oauth_info][ccgInfo][sandboxAud]: ausdg7guis2TYDlFe2p7
           - Last url segment taken from the issuer property
           - 'https://deptva-eval.okta.com/oauth2/ausdg7guis2TYDlFe2p7' -> 'ausdg7guis2TYDlFe2p7'
+
+          api_metadatum_attributes[oauth_info][ccgInfo][sandboxWellKnownConfig]:
+          - https://sandbox-api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration
 
           api_metadatum_attributes[oauth_info][ccgInfo][scopes]: claims.read,claims.write
           - CSV list of scopes provided in ticket, all must be in scopes_supported property in config
 
           ### ACG
           - From the .well-known openid-configuration
-          - https://api.va.gov/oauth2/health/system/v1/.well-known/openid-configuration
+          - https://api.va.gov/oauth2/health/v1/.well-known/openid-configuration
+          - https://sandbox-api.va.gov/oauth2/health/v1/.well-known/openid-configuration
+          - When on prod, all values except for productionAud and productionWellKnownConfig should come
+            from the sandbox .well-known config file
 
-          api_metadatum_attributes[oauth_info][acgInfo][baseAuthPath]: /oauth2/health/system/v1
+          api_metadatum_attributes[oauth_info][acgInfo][baseAuthPath]: /oauth2/health/v1
           - Remove the domain from the front and /token from the end of token_endpoint
-          - 'https://api.va.gov/oauth2/health/system/v1/token' -> '/oauth2/claims/system/v1'
+          - 'https://api.va.gov/oauth2/health/v1/token' -> '/oauth2/health/v1'
+
+          api_metadatum_attributes[oauth_info][acgInfo][productionWellKnownConfig]:
+          - https://api.va.gov/oauth2/health/v1/.well-known/openid-configuration
+
+          api_metadatum_attributes[oauth_info][acgInfo][sandboxWellKnownConfig]:
+          - https://sandbox-api.va.gov/oauth2/health/v1/.well-known/openid-configuration
 
           api_metadatum_attributes[oauth_info][acgInfo][scopes]: patient/AllergyIntolerance.read,patient/Appointment.read,etc...
           - CSV list of scopes provided in ticket, all must be in scopes_supported property in config

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ values =  HTTParty.get('https://urlhaus.abuse.ch/downloads/text/').body
                                                                   .split("\r\n")
                                                                   .delete_if { |line| line.starts_with?('#') }
                                                                   .map { |line| [line] }
-MaliciousUrl.import columns, values, validate: false, on_duplicate_key_ignore: true
+# MaliciousUrl.import columns, values, validate: false, on_duplicate_key_ignore: true
 
 
 appeals_category = ApiCategory.create(
@@ -215,12 +215,16 @@ claims_api.update(  auth_server_access_key: 'AUTHZ_SERVER_CLAIMS',
    oauth_info: {
      acgInfo: {
        baseAuthPath: '/oauth2/claims/v1',
+       productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/claims/v1/.well-known/openid-configuration',
+       sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/claims/v1/.well-known/openid-configuration',
        scopes: ['profile', 'openid', 'offline_access', 'claim.read', 'claim.write'],
      },
      ccgInfo: {
        baseAuthPath: '/oauth2/claims/system/v1',
        productionAud: 'ausajojxqhTsDSVlA297',
+       productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration',
        sandboxAud: 'ausdg7guis2TYDlFe2p7',
+       sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/claims/system/v1/.well-known/openid-configuration',
        scopes: ['claim.read', 'claim.write'],
      },
    }.to_json,
@@ -344,7 +348,9 @@ lgy_guaranty_remittance_api.update(
     ccgInfo: {
       baseAuthPath: '/oauth2/loan-guaranty/system/v1',
       productionAud: 'ausbts6ndxFQDyeBM297',
+      productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/loan-guaranty/system/v1/.well-known/openid-configuration',
       sandboxAud: 'auseavl6o5AjGZr2n2p7',
+      sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/loan-guaranty/system/v1/.well-known/openid-configuration',
       scopes: ['system.loan-remittance.read', 'system.loan-remittance.write', 'system.remediation-evidence.write'],
     },
   }.to_json,
@@ -428,7 +434,7 @@ veteran_letter_generator_api = Api.create(name: 'veteran-letters')
 veteran_letter_generator_api.update(
   auth_server_access_key: 'TBD',
   api_environments_attributes: {
-    metadata_url: 'https://dev-api.va.gov/internal/docs/veteran-letters/metadata.json',
+    metadata_url: 'https://dev-api.va.gov/internal/docs/va-letter-generator/metadata.json',
     environments_attributes: {
       name: ['sandbox', 'production']
     }
@@ -444,9 +450,11 @@ veteran_letter_generator_api.update(
    url_fragment: 'va_letter_generator',
    oauth_info: {
       ccgInfo: {
-        baseAuthPath: '/oauth2/veteran-letters/system/v1',
+        baseAuthPath: '/oauth2/va-letter-generator/system/v1',
         productionAud: 'TBD',
+        productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/va-letter-generator/system/v1/.well-known/openid-configuration',
         sandboxAud: 'TBD',
+        sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/va-letter-generator/system/v1/.well-known/openid-configuration',
         scopes: ['letters.read'],
       },
     }.to_json,
@@ -476,6 +484,8 @@ veteran_verification_api.update(
    oauth_info: {
     acgInfo: {
       baseAuthPath: '/oauth2/veteran-verification/v1',
+      productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/veteran-verification/v1/.well-known/openid-configuration',
+      sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/veteran-verification/v1/.well-known/openid-configuration',
       scopes: [
         'profile',
         'openid',
@@ -529,7 +539,9 @@ pgd_api.update(
     ccgInfo: {
       baseAuthPath: '/oauth2/pgd/system/v1',
       productionAud: 'aus8ew475sXlNGpbp297',
+      productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/pgd/system/v1/.well-known/openid-configuration',
       sandboxAud: 'aus8x27nv4g4BS01v2p7',
+      sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/pgd/system/v1/.well-known/openid-configuration',
       scopes: [
         'launch',
         'patient/Observation.read',
@@ -571,6 +583,8 @@ community_care_api.update(
    oauth_info: {
     acgInfo: {
       baseAuthPath: '/oauth2/community-care/v1',
+      productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/community-care/v1/.well-known/openid-configuration',
+      sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/community-care/v1/.well-known/openid-configuration',
       scopes: [
         'profile',
         'openid',
@@ -632,6 +646,8 @@ clinical_fhir_api.update(
    oauth_info: {
     acgInfo: {
       baseAuthPath: '/oauth2/clinical-health/v1',
+      productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/clinical-health/system/v1/.well-known/openid-configuration',
+      sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/clinical-health/system/v1/.well-known/openid-configuration',
       scopes: [
         'profile',
         'openid',
@@ -671,6 +687,8 @@ fhir_health_api.update(
    oauth_info: {
       acgInfo: {
         baseAuthPath: '/oauth2/health/v1',
+        productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/health/v1/.well-known/openid-configuration',
+        sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/health/v1/.well-known/openid-configuration',
         scopes: [
           'profile',
           'openid',
@@ -698,7 +716,9 @@ fhir_health_api.update(
       ccgInfo: {
         baseAuthPath: '/oauth2/health/system/v1',
         productionAud: 'aus8evxtl123l7Td3297',
+        productionWellKnownConfig: 'https://dev-api.va.gov/oauth2/health/system/v1/.well-known/openid-configuration',
         sandboxAud: 'aus8nm1q0f7VQ0a482p7',
+        sandboxWellKnownConfig: 'https://dev-api.va.gov/oauth2/health/system/v1/.well-known/openid-configuration',
         scopes: [
           'launch',
           'system/AllergyIntolerance.read',

--- a/spec/factories/api_metadata.rb
+++ b/spec/factories/api_metadata.rb
@@ -11,13 +11,15 @@ FactoryBot.define do
       {
         acgInfo: {
           baseAuthPath: "/oauth2/#{Faker::Lorem.word}/v1",
-          scopes: Faker::Lorem.words(number: 5)
+          scopes: Faker::Lorem.words(number: 5),
+          wellKnownConfig: Faker::Internet.url
         },
         ccgInfo: {
           baseAuthPath: "/oauth2/#{Faker::Lorem.word}/system/v1",
           productionAud: Faker::Internet.slug,
           sandboxAud: Faker::Internet.slug,
-          scopes: Faker::Lorem.words(number: 2)
+          scopes: Faker::Lorem.words(number: 2),
+          wellKnownConfig: Faker::Internet.url
         }
       }.to_json
     end

--- a/spec/factories/api_metadata.rb
+++ b/spec/factories/api_metadata.rb
@@ -11,15 +11,17 @@ FactoryBot.define do
       {
         acgInfo: {
           baseAuthPath: "/oauth2/#{Faker::Lorem.word}/v1",
-          scopes: Faker::Lorem.words(number: 5),
-          wellKnownConfig: Faker::Internet.url
+          productionWellKnownConfig: Faker::Internet.url,
+          sandboxWellKnownConfig: Faker::Internet.url,
+          scopes: Faker::Lorem.words(number: 5)
         },
         ccgInfo: {
           baseAuthPath: "/oauth2/#{Faker::Lorem.word}/system/v1",
           productionAud: Faker::Internet.slug,
+          productionWellKnownConfig: Faker::Internet.url,
           sandboxAud: Faker::Internet.slug,
-          scopes: Faker::Lorem.words(number: 2),
-          wellKnownConfig: Faker::Internet.url
+          sandboxWellKnownConfig: Faker::Internet.url,
+          scopes: Faker::Lorem.words(number: 2)
         }
       }.to_json
     end

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -28,14 +28,16 @@ FactoryBot.define do
           ccgInfo: {
             baseAuthPath: Faker::Internet.domain_name,
             productionAud: Faker::Lorem.word,
+            productionWellKnownConfig: Faker::Internet.url,
             sandboxAud: Faker::Lorem.word,
-            scopes: 'test.true,test.false',
-            wellKnownConfig: Faker::Internet.url
+            sandboxWellKnownConfig: Faker::Internet.url,
+            scopes: 'test.true,test.false'
           },
           acgInfo: {
             baseAuthPath: Faker::Internet.domain_name,
-            scopes: 'test.true,test.false',
-            wellKnownConfig: Faker::Internet.url
+            productionWellKnownConfig: Faker::Internet.url,
+            sandboxWellKnownConfig: Faker::Internet.url,
+            scopes: 'test.true,test.false'
           }
         },
         api_category_attributes: {

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -29,11 +29,13 @@ FactoryBot.define do
             baseAuthPath: Faker::Internet.domain_name,
             productionAud: Faker::Lorem.word,
             sandboxAud: Faker::Lorem.word,
-            scopes: 'test.true,test.false'
+            scopes: 'test.true,test.false',
+            wellKnownConfig: Faker::Internet.url
           },
           acgInfo: {
             baseAuthPath: Faker::Internet.domain_name,
-            scopes: 'test.true,test.false'
+            scopes: 'test.true,test.false',
+            wellKnownConfig: Faker::Internet.url
           }
         },
         api_category_attributes: {


### PR DESCRIPTION
https://vajira.max.gov/browse/API-22785

This adds support for the .well-known config urls to be added to the oauth_info field. This is in support of automation around API scopes.