### PR TITLE
[API-25451] - Fix bug with locating auth types

### DIFF
--- a/app/models/api.rb
+++ b/app/models/api.rb
@@ -32,8 +32,8 @@ class Api < ApplicationRecord
     types << AUTH_TYPES[:apikey] if acl.present?
     if api_metadatum.oauth_info.present?
       parsed_oauth_info = JSON.parse(api_metadatum.oauth_info)
-      types << AUTH_TYPES[:acg] if parsed_oauth_info['acgInfo']['sandboxAud'].present?
-      types << AUTH_TYPES[:ccg] if parsed_oauth_info['ccgInfo']['sandboxAud'].present?
+      types << AUTH_TYPES[:acg] if parsed_oauth_info.dig('acgInfo', 'sandboxAud').present?
+      types << AUTH_TYPES[:ccg] if parsed_oauth_info.dig('ccgInfo', 'sandboxAud').present?
     end
     types.uniq
   end

--- a/spec/factories/api_metadata.rb
+++ b/spec/factories/api_metadata.rb
@@ -29,5 +29,35 @@ FactoryBot.define do
     end
     api_category { association :api_category }
     api_release_notes { build_list :api_release_note, 3 }
+
+    trait :without_acg do
+      oauth_info do
+        {
+          ccgInfo: {
+            baseAuthPath: "/oauth2/#{Faker::Lorem.word}/system/v1",
+            productionAud: Faker::Internet.slug,
+            productionWellKnownConfig: Faker::Internet.url,
+            sandboxAud: Faker::Internet.slug,
+            sandboxWellKnownConfig: Faker::Internet.url,
+            scopes: Faker::Lorem.words(number: 2)
+          }
+        }.to_json
+      end
+    end
+
+    trait :without_ccg do
+      oauth_info do
+        {
+          acgInfo: {
+            baseAuthPath: "/oauth2/#{Faker::Lorem.word}/v1",
+            productionWellKnownConfig: Faker::Internet.url,
+            sandboxWellKnownConfig: Faker::Internet.url,
+            productionAud: Faker::Internet.slug,
+            sandboxAud: Faker::Internet.slug,
+            scopes: Faker::Lorem.words(number: 5)
+          }
+        }.to_json
+      end
+    end
   end
 end

--- a/spec/factories/apis.rb
+++ b/spec/factories/apis.rb
@@ -24,5 +24,21 @@ FactoryBot.define do
       acl { nil }
       auth_server_access_key { 'PROVIDER' }
     end
+
+    trait :no_acl do
+      acl { nil }
+    end
+
+    trait :no_acg do
+      api_metadatum { build(:api_metadatum, :without_acg) }
+    end
+
+    trait :no_ccg do
+      api_metadatum { build(:api_metadatum, :without_ccg) }
+    end
+
+    factory :api_without_acl, traits: [:no_acl]
+    factory :api_without_acg, traits: [:no_acg]
+    factory :api_without_ccg, traits: [:no_ccg]
   end
 end

--- a/spec/models/api_spec.rb
+++ b/spec/models/api_spec.rb
@@ -89,4 +89,62 @@ RSpec.describe Api, type: :model do
       }
     end
   end
+
+  describe "'locate_auth_types'" do
+    context 'when the api has all auth types' do
+      subject do
+        create(:api)
+      end
+
+      it 'correctly returns all auth types' do
+        auth_types = subject.locate_auth_types
+
+        expect(auth_types).to include('apikey')
+        expect(auth_types).to include('oauth/acg')
+        expect(auth_types).to include('oauth/ccg')
+      end
+    end
+
+    context "when the api does not support the 'apiKey' auth type" do
+      subject do
+        create(:api_without_acl)
+      end
+
+      it "does not contain the 'apiKey' auth type" do
+        auth_types = subject.locate_auth_types
+
+        expect(auth_types).not_to include('apikey')
+        expect(auth_types).to include('oauth/acg')
+        expect(auth_types).to include('oauth/ccg')
+      end
+    end
+
+    context "when the api does not support the 'acg' auth type" do
+      subject do
+        create(:api_without_acg)
+      end
+
+      it "does not contain the 'oauth/acg' auth type and does not blow up" do
+        auth_types = subject.locate_auth_types
+
+        expect(auth_types).to include('apikey')
+        expect(auth_types).not_to include('oauth/acg')
+        expect(auth_types).to include('oauth/ccg')
+      end
+    end
+
+    context "when the api does not support the 'ccg' auth type" do
+      subject do
+        create(:api_without_ccg)
+      end
+
+      it "does not contain the 'oauth/ccg' auth type and does not blow up" do
+        auth_types = subject.locate_auth_types
+
+        expect(auth_types).to include('apikey')
+        expect(auth_types).to include('oauth/acg')
+        expect(auth_types).not_to include('oauth/ccg')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Original Issue :: [API-25451](https://vajira.max.gov/browse/API-25451)

- Fixes bug in `api.locate_auth_types` that would raise when either `acgInfo` or `ccgInfo` was not present in the `api.api_metadatum.oauth_info` hash.