### PR TITLE
Tweak MR markdown template file

### DIFF
--- a/.github/workflows/assets/maintenance-request.md
+++ b/.github/workflows/assets/maintenance-request.md
@@ -3,7 +3,7 @@ name: Maintenance Request
 about: Request a change to Lab/Sandbox or the Production environment.
 title: __mr_summary__ (YYYY/MM/DD HH:MM ET)
 labels: maintenance-request
-assignees: mramirez-va, evelez-va
+assignees: mramirez-va,evelez-va
 ---
 
 # MAINTENANCE REQUEST


### PR DESCRIPTION
Removes the space between the `assignees` on the maintenance request markdown template to see if that will satisfy the GitHub Action Workflow.