### PR TITLE
API-27989 - Add GHA workflow to monitor security alerts

### DIFF
--- a/.github/workflows/notify-security-alerts.yml
+++ b/.github/workflows/notify-security-alerts.yml
@@ -1,0 +1,27 @@
+name: Notify Security Alerts
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 15 * * 1-5
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    name: Check for security alerts and notify team via Slack
+    steps:
+      - id: check_for_security_alerts
+        name: Check for security alerts
+        run: |
+          echo ${{ secrets.GIT_AUTO_DEPLOY_TOKEN }} | gh auth login --with-token
+          gh api '/repos/department-of-veterans-affairs/lighthouse-platform-backend/code-scanning/alerts?state=open' \
+            > code-scanning.json
+          cat code-scanning.json
+          if [ "[]" == "$(cat code-scanning.json)" ]; then
+            echo "security_alert_exists='false'" >> $GITHUB_OUTPUT
+          else
+            echo "security_alert_exists='true'" >> $GITHUB_OUTPUT
+          fi
+      - id: send_slack_message
+        name: Send Slack Message
+        if: steps.check_for_security_alerts.outputs.security_alert_exists == 'true'
+        run: |
+            echo 'Sending Slack Message'


### PR DESCRIPTION
Original Issue :: [API-27989](https://jira.devops.va.gov/browse/API-27989)

- Adds a pretty basic GHA workflow that just checks for the existence of any code scanning alerts.
- If any alerts are found, it'll print out a message.
- Need this to be in `Master` before I can test it out and iterate on it further to add things such as Slack integration.