### PR TITLE
[API-29438] - Allow "Contact Us" form submission emails in lower envs

### DIFF
--- a/app/api/v0/support.rb
+++ b/app/api/v0/support.rb
@@ -50,7 +50,6 @@ module V0
         protect_from_forgery
 
         body false
-        return unless Flipper.enabled? :send_emails
 
         email_params = declared(params, include_missing: false)
         if params[:type] == 'PUBLISHING'

--- a/spec/api/v0/support_spec.rb
+++ b/spec/api/v0/support_spec.rb
@@ -6,60 +6,24 @@ describe V0::Support, type: :request do
   describe 'receives contact-us based requests from consumers' do
     let(:request) { build(:support_request, :mock_front_end_request) }
 
-    context 'with flipper enabled' do
-      before do
-        Flipper.enable :send_emails
-      end
-
-      after do
-        Flipper.disable :send_emails
-      end
-
-      it 'sends an email to support' do
-        email = double
-        allow(SupportMailer).to receive(:consumer_support_email).and_return(email)
-        expect(email).to receive(:deliver_later)
-        post '/platform-backend/v0/support/contact-us/requests', params: request
-        expect(response.code).to eq('204')
-      end
-    end
-
-    context 'with flipper disabled' do
-      it 'does not send an email' do
-        expect(SupportMailer).not_to receive(:consumer_support_email)
-        post '/platform-backend/v0/support/contact-us/requests', params: request
-        expect(response.code).to eq('204')
-      end
+    it 'sends an email to support' do
+      email = double
+      allow(SupportMailer).to receive(:consumer_support_email).and_return(email)
+      expect(email).to receive(:deliver_later)
+      post '/platform-backend/v0/support/contact-us/requests', params: request
+      expect(response.code).to eq('204')
     end
   end
 
   describe 'receives contact-us based requests about publishing APIs' do
     let(:request) { build(:support_request, :set_publishing, :mock_front_end_request) }
 
-    context 'with flipper enabled' do
-      before do
-        Flipper.enable :send_emails
-      end
-
-      after do
-        Flipper.disable :send_emails
-      end
-
-      it 'sends an email to support' do
-        email = double
-        allow(SupportMailer).to receive(:publishing_support_email).and_return(email)
-        expect(email).to receive(:deliver_later)
-        post '/platform-backend/v0/support/contact-us/requests', params: request
-        expect(response.code).to eq('204')
-      end
-    end
-
-    context 'with flipper disabled' do
-      it 'does not send an email' do
-        expect(SupportMailer).not_to receive(:publishing_support_email)
-        post '/platform-backend/v0/support/contact-us/requests', params: request
-        expect(response.code).to eq('204')
-      end
+    it 'sends an email to support' do
+      email = double
+      allow(SupportMailer).to receive(:publishing_support_email).and_return(email)
+      expect(email).to receive(:deliver_later)
+      post '/platform-backend/v0/support/contact-us/requests', params: request
+      expect(response.code).to eq('204')
     end
   end
 end


### PR DESCRIPTION
Original Issue :: [API-29438](https://jira.devops.va.gov/browse/API-29438)
- Allows "Contact Us" form submissions to send emails to Marmoset in lower envs.
  - I have updated the Dev and Staging `/dvp/$ENVIRONMENT/platform-backend/support_email` env vars in AWS to the values requested by Marmoset.  (see Jira ticket for details)