### PR TITLE
[API-30848] - Add is_stealth_launched boolean field

### DIFF
--- a/app/api/v0/entities/legacy/api_provider_entity.rb
+++ b/app/api/v0/entities/legacy/api_provider_entity.rb
@@ -79,6 +79,7 @@ module V0
         expose :restricted_access_details, as: :restrictedAccessDetails
         expose :restricted_access_toggle, as: :restrictedAccessToggle
         expose :url_slug, as: :urlSlug
+        expose :is_stealth_launched, as: :isStealthLaunched
       end
     end
   end

--- a/db/migrate/20230111172809_add_well_known_configs.rb
+++ b/db/migrate/20230111172809_add_well_known_configs.rb
@@ -1,5 +1,5 @@
 class AddWellKnownConfigs < ActiveRecord::Migration[7.0]
   def up
-    Rake::Task['lpb:seedWellKnownConfigValues'].invoke
+    # Rake::Task['lpb:seedWellKnownConfigValues'].invoke
   end
 end

--- a/db/migrate/20230125163247_add_audience_values.rb
+++ b/db/migrate/20230125163247_add_audience_values.rb
@@ -1,5 +1,5 @@
 class AddAudienceValues < ActiveRecord::Migration[7.0]
   def up
-    Rake::Task['lpb:seedAudienceValues'].invoke
+    # Rake::Task['lpb:seedAudienceValues'].invoke
   end
 end

--- a/db/migrate/20230208190820_add_audience_values_v2.rb
+++ b/db/migrate/20230208190820_add_audience_values_v2.rb
@@ -1,5 +1,5 @@
 class AddAudienceValuesV2 < ActiveRecord::Migration[7.0]
   def up
-    Rake::Task['lpb:seedAudienceValues'].invoke
+    # Rake::Task['lpb:seedAudienceValues'].invoke
   end
 end

--- a/db/migrate/20230404203017_seed_new_information_architecture_fields.rb
+++ b/db/migrate/20230404203017_seed_new_information_architecture_fields.rb
@@ -1,5 +1,5 @@
 class SeedNewInformationArchitectureFields < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedIAFieldValues'].invoke
+    # Rake::Task['lpb:seedIAFieldValues'].invoke
   end
 end

--- a/db/migrate/20230622195231_seed_api_overview_page_data.rb
+++ b/db/migrate/20230622195231_seed_api_overview_page_data.rb
@@ -1,5 +1,5 @@
 class SeedApiOverviewPageData < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedOverviewPageContent'].invoke
+    # Rake::Task['lpb:seedOverviewPageContent'].invoke
   end
 end

--- a/db/migrate/20230630195232_update_api_overview_page_data.rb
+++ b/db/migrate/20230630195232_update_api_overview_page_data.rb
@@ -1,5 +1,5 @@
 class UpdateApiOverviewPageData < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedOverviewPageContent'].invoke
+    # Rake::Task['lpb:seedOverviewPageContent'].invoke
   end
 end

--- a/db/migrate/20230701151610_fix_category_url_slug_values.rb
+++ b/db/migrate/20230701151610_fix_category_url_slug_values.rb
@@ -1,5 +1,5 @@
 class FixCategoryUrlSlugValues < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:fixCategoryUrlSlugValues'].invoke
+    # Rake::Task['lpb:fixCategoryUrlSlugValues'].invoke
   end
 end

--- a/db/migrate/20230703185426_update_api_overview_content_again.rb
+++ b/db/migrate/20230703185426_update_api_overview_content_again.rb
@@ -1,5 +1,5 @@
 class UpdateApiOverviewContentAgain < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedOverviewPageContent'].invoke
+    # Rake::Task['lpb:seedOverviewPageContent'].invoke
   end
 end

--- a/db/migrate/20230703211827_update_api_descriptions.rb
+++ b/db/migrate/20230703211827_update_api_descriptions.rb
@@ -1,5 +1,5 @@
 class UpdateApiDescriptions < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:updateApiDescriptions'].invoke
+    # Rake::Task['lpb:updateApiDescriptions'].invoke
   end
 end

--- a/db/migrate/20230703213757_update_title_for_higher_level_reviews.rb
+++ b/db/migrate/20230703213757_update_title_for_higher_level_reviews.rb
@@ -1,5 +1,5 @@
 class UpdateTitleForHigherLevelReviews < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedOverviewPageContent'].invoke
+    # Rake::Task['lpb:seedOverviewPageContent'].invoke
   end
 end

--- a/db/migrate/20230705164852_update_veteran_verification_url_slug.rb
+++ b/db/migrate/20230705164852_update_veteran_verification_url_slug.rb
@@ -1,5 +1,5 @@
 class UpdateVeteranVerificationUrlSlug < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:updateVeteranVerificationUrlSlug'].invoke
+    # Rake::Task['lpb:updateVeteranVerificationUrlSlug'].invoke
   end
 end

--- a/db/migrate/20230705192408_fix_overview_page_content.rb
+++ b/db/migrate/20230705192408_fix_overview_page_content.rb
@@ -1,7 +1,7 @@
 class FixOverviewPageContent < ActiveRecord::Migration[7.0]
   def change
     def change
-      Rake::Task['lpb:seedOverviewPageContent'].invoke
+      # Rake::Task['lpb:seedOverviewPageContent'].invoke
     end
   end
 end

--- a/db/migrate/20230706184309_actually_fix_overview_page_content.rb
+++ b/db/migrate/20230706184309_actually_fix_overview_page_content.rb
@@ -1,5 +1,5 @@
 class ActuallyFixOverviewPageContent < ActiveRecord::Migration[7.0]
   def change
-    Rake::Task['lpb:seedOverviewPageContent'].invoke
+    # Rake::Task['lpb:seedOverviewPageContent'].invoke
   end
 end

--- a/db/migrate/20231016202941_add_stealth_launched_field.rb
+++ b/db/migrate/20231016202941_add_stealth_launched_field.rb
@@ -1,0 +1,5 @@
+class AddStealthLaunchedField < ActiveRecord::Migration[7.0]
+  def change
+    add_column :api_metadata, :is_stealth_launched, :boolean, default: false
+  end
+end

--- a/db/migrate/20231017151330_default_stealth_launched_to_true.rb
+++ b/db/migrate/20231017151330_default_stealth_launched_to_true.rb
@@ -1,0 +1,9 @@
+class DefaultStealthLaunchedToTrue < ActiveRecord::Migration[7.0]
+  def up
+    change_column :api_metadata, :is_stealth_launched, :boolean, default: true
+  end
+
+  def down
+    change_column :api_metadata, :is_stealth_launched, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_15_150722) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_151330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_15_150722) do
     t.boolean "restricted_access_toggle"
     t.string "url_slug"
     t.boolean "block_sandbox_form", default: false
+    t.boolean "is_stealth_launched", default: true
     t.index ["api_category_id"], name: "index_api_metadata_on_api_category_id"
     t.index ["api_id"], name: "index_api_metadata_on_api_id"
     t.index ["discarded_at"], name: "index_api_metadata_on_discarded_at"


### PR DESCRIPTION
https://jira.devops.va.gov/browse/API-30848

Adds `is_stealth_launched` field to the `api_metadata` database table and exposes it through `isStealthLaunched` on the `legacy.json` API endpoint. The reason for the two migrations was to first default the field to false (which all current APIs should have) and then set it to true so that all future APIs will start as being stealth launched so Okapi can audit newly added APIs before making them visible to the public.

I also removed the rake tasks that we were using in migrations as they were causing issues when spinning up a new instance of the app. In the future we shouldn't use this pattern of calling a rake task within a migration. (That was my bad idea and this is me realizing and reversing it)