### PR TITLE
[API-31348] - Remove reference to deprecated Docker image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-ARG VERSION
-FROM vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14
-
-WORKDIR /etc/build
-
-RUN retry curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,7 @@
+ARG VERSION
+FROM vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14
+
+WORKDIR /etc/build
+
+RUN retry curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/developer-utils:latest
 
 WORKDIR /etc/build
 


### PR DESCRIPTION
Original Issue :: [API-31348](https://jira.devops.va.gov/browse/API-31348)

- Removes the reference to the `vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14` Docker image
- Replaces with a reference to the `ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/developer-utils:latest` Docker image
- Initially, this PR tried to just delete the `Dockerfile.build` file because it was thought that the file wasn't used.  But it turns out that the file is required by the Jenkins build config.  So we fell back to just updating the Docker image that the file points at.