### PR TITLE
[API-31636] - Skip ECSCredentials call

### DIFF
--- a/app/services/aws_s3_service.rb
+++ b/app/services/aws_s3_service.rb
@@ -3,7 +3,7 @@
 class AwsS3Service
   def get_object(params)
     options = {
-      region: ENV.fetch('AWS_REGION'),
+      region: ENV.fetch('AWS_REGION')
     }
     s3 = Aws::S3::Client.new(options)
     response = s3.get_object(bucket: params[:bucket], key: params[:key])

--- a/app/services/aws_s3_service.rb
+++ b/app/services/aws_s3_service.rb
@@ -2,10 +2,8 @@
 
 class AwsS3Service
   def get_object(params)
-    credentials = Aws::ECSCredentials.new
     options = {
       region: ENV.fetch('AWS_REGION'),
-      credentials: credentials
     }
     s3 = Aws::S3::Client.new(options)
     response = s3.get_object(bucket: params[:bucket], key: params[:key])


### PR DESCRIPTION
https://jira.devops.va.gov/browse/API-31636

Local testing seems to confirm that calling `Aws::ECSCredentials.new` is not required and is actually causing the Ruby gem to create new credentials vs inheriting the existing credentials that exist within the ECS container already.