### PR TITLE
[API-33844] - Add rescue around deeplink error

### DIFF
--- a/lib/tasks/lpb.rake
+++ b/lib/tasks/lpb.rake
@@ -565,7 +565,11 @@ namespace :lpb do
     CSV.open(csv_file_name, 'w') do |csv|
       csv << %w[email links]
       test_users.each do |user|
-        csv << [user.email, user.get_deeplinks]
+        begin
+          csv << [user.email, user.get_deeplinks]
+        rescue
+          puts "Error caught with TestUserEmail#id:#{user.id}"
+        end
       end
     end
     puts 'Created and populated test-users-with-deeplinks.csv file.'


### PR DESCRIPTION
https://jira.devops.va.gov/browse/API-33844

Just adding a wrapper to allow for easier debugging of an error during the first run of the script in qa.