### PR TITLE
[API-33844] - Confirm unsubscribe is false for export

### DIFF
--- a/app/models/test_user_email.rb
+++ b/app/models/test_user_email.rb
@@ -4,7 +4,7 @@ class TestUserEmail < ApplicationRecord
   include ApplicationHelper
 
   def get_deeplinks
-    user = User.where(email: email).first
+    user = User.joins(:consumer).merge(Consumer.where(unsubscribe: false)).where(email: email).first
     links = ''
     links += single_link(user, 'community-care-eligibility', 'Community Care Eligibility API', communityCare)
     links += single_link(user, 'patient-health', 'Patient Health API (FHIR)', health)


### PR DESCRIPTION
https://jira.devops.va.gov/browse/API-33844

This will confirm that the Consumer record attached to the User has not been marked as unsubscribed from future emails. While I would typically expect for this to be checked within the task ([potentially here](https://github.com/department-of-veterans-affairs/lighthouse-platform-backend/blob/7baa93c41f2b7efc268fce5a6f3af92976c89b2c/lib/tasks/lpb.rake#L569-L577)), given the short timeline and there already being a `begin/rescue` block around this call, we can easily get away with just making the database query more specific as any errors will be caught as a record that we expect should be skipped.