### PR TITLE
[API-34175] - Remove dig in favor of direct access to prop

### DIFF
--- a/app/views/sandbox_mailer/consumer_sandbox_signup.html.erb
+++ b/app/views/sandbox_mailer/consumer_sandbox_signup.html.erb
@@ -14,7 +14,7 @@
   <% if @okta_consumers.dig(:ccg, :credentials).present? %>
     <div>Here's your Client Credentials Grant OAuth Client ID: <pre><%= @okta_consumers.dig(:ccg, :credentials, :oauthClient, :client_id) %></pre></div><br />
 
-    <div>Please visit our OAuth documentation for implementation guidelines: <a href="https://developer.va.gov/explore/api/<%= get_api_metadata(@request[:apis]).dig('urlSlug') %>/client-credentials">https://developer.va.gov/explore/api/<%= get_api_metadata(@request[:apis]).dig('urlSlug') %>/client-credentials</a></div><br />
+    <div>Please visit our OAuth documentation for implementation guidelines: <a href="https://developer.va.gov/explore/api/<%= @request[:apis].first.api_metadatum.url_slug %>/client-credentials">https://developer.va.gov/explore/api/<%= @request[:apis].first.api_metadatum.url_slug %>/client-credentials</a></div><br />
   <% end %>
 
   <% if @okta_consumers.dig(:acg, :credentials).present? %>


### PR DESCRIPTION
https://jira.devops.va.gov/browse/API-34175

Modifications to the email template failed to properly address CCG signups causing the signups emails from those API types to fail to send while simultaneously still showing the success page on the sandbox signup form. This resolves that bug in the email template.