### PR TITLE
[API-34610] - Update link to calculation doc

### DIFF
--- a/app/services/slack/report_service.rb
+++ b/app/services/slack/report_service.rb
@@ -122,7 +122,7 @@ module Slack
       message[:blocks] << { type: 'divider' }
       message[:blocks] << {
         text: {
-          text: '_Have questions about these numbers? Read <https://community.max.gov/display/VAExternal/Calculating Sandbox Signups|how we calculate signups>._',
+          text: '_Have questions about these numbers? Read <https://confluence.devops.va.gov/display/VAExternal/Calculating+Sandbox+Signups|how we calculate signups>._',
           type: 'mrkdwn'
         },
         type: 'section'


### PR DESCRIPTION
Original Issue :: [API-34610](https://jira.devops.va.gov/browse/API-34610)

- Updates the link to the calculation doc referenced in the weekly/monthly sandbox signup reports in Slack [ref](https://lighthouseva.slack.com/archives/CEL8NK8JG/p1709550001082679)